### PR TITLE
Added Rust and Python templates

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,16 @@
         path = ./simple-container;
         description = "A NixOS container running apache-httpd";
       };
+    
+      python = {
+        path = ./python;
+        description = "Python template, using poetry2nix";
+      };
+
+      rust = {
+        path = ./rust;
+        description = "Rust template, using Naersk";
+      };
 
     };
 

--- a/python/.envrc
+++ b/python/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/python/.github/workflows/build_nix.yml
+++ b/python/.github/workflows/build_nix.yml
@@ -1,0 +1,13 @@
+name: "Build legacy Nix package on Ubuntu"
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v12
+      - name: Building package
+        run: nix-build . -A defaultPackage.x86_64-linux

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,6 @@
+__pycache__
+secrets.py
+runs
+.ipynb_*
+*.csv
+.direnv

--- a/python/default.nix
+++ b/python/default.nix
@@ -1,0 +1,7 @@
+(import (
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
+) {
+  src =  ./.;
+}).defaultNix

--- a/python/flake.nix
+++ b/python/flake.nix
@@ -1,0 +1,29 @@
+{
+    inputs = {
+        nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+        utils.url = "github:numtide/flake-utils";
+    };
+
+    outputs = {self, nixpkgs, utils}:
+    let out = system:
+    let pkgs = nixpkgs.legacyPackages."${system}";
+    in {
+
+        devShell = pkgs.mkShell {
+            buildInputs = with pkgs; [
+                python3Packages.poetry
+            ];
+        };
+
+        defaultPackage = with pkgs.poetry2nix; mkPoetryApplication {
+            projectDir = ./.;
+            preferWheels = true;
+        };
+
+        defaultApp = utils.lib.mkApp {
+            drv = self.defaultPackage."${system}";
+        };
+
+    }; in with utils.lib; eachSystem defaultSystems out;
+
+}

--- a/python/shell.nix
+++ b/python/shell.nix
@@ -1,0 +1,7 @@
+(import (
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
+) {
+  src =  ./.;
+}).shellNix

--- a/rust/.envrc
+++ b/rust/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/rust/.github/workflows/build_nix.yml
+++ b/rust/.github/workflows/build_nix.yml
@@ -1,0 +1,13 @@
+name: "Build legacy Nix package on Ubuntu"
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v12
+      - name: Building package
+        run: nix-build . -A defaultPackage.x86_64-linux

--- a/rust/default.nix
+++ b/rust/default.nix
@@ -1,0 +1,7 @@
+(import (
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
+) {
+  src =  ./.;
+}).defaultNix

--- a/rust/flake.nix
+++ b/rust/flake.nix
@@ -1,0 +1,29 @@
+{
+
+  inputs = {
+    naersk.url = "github:nmattia/naersk/master";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils, naersk }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        naersk-lib = pkgs.callPackage naersk {};
+      in {
+
+        defaultPackage = naersk-lib.buildPackage ./.;
+
+        defaultApp = utils.mkApp {
+            drv = self.defaultPackage."${system}";
+        };
+
+        devShell = with pkgs; mkShell {
+          buildInputs = [ cargo rustc rustfmt pre-commit rustPackages.clippy ];
+          RUST_SRC_PATH = rustPlatform.rustLibSrc;
+        };
+
+      });
+
+}

--- a/rust/shell.nix
+++ b/rust/shell.nix
@@ -1,0 +1,7 @@
+(import (
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
+) {
+  src =  ./.;
+}).shellNix


### PR DESCRIPTION
I've noticed that there's no templates here)

Probably would need to create some common seed, e.g. for gh actions and envrc, but that's out of scope of this pr.

Python template uses poetry2nix and poetry,

Rust template uses Naersk flake and, obviously, cargo.