### PR TITLE
Support aarch64-{linux,darwin} by default

### DIFF
--- a/bash-hello/flake.nix
+++ b/bash-hello/flake.nix
@@ -11,7 +11,7 @@
       version = builtins.substring 0 8 self.lastModifiedDate;
 
       # System types to support.
-      supportedSystems = [ "x86_64-linux" "x86_64-darwin" ];
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
 
       # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
       forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);

--- a/c-hello/flake.nix
+++ b/c-hello/flake.nix
@@ -11,7 +11,7 @@
       version = builtins.substring 0 8 self.lastModifiedDate;
 
       # System types to support.
-      supportedSystems = [ "x86_64-linux" "x86_64-darwin" ];
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
 
       # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
       forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);


### PR DESCRIPTION
Something like https://github.com/NixOS/nixpkgs/pull/123117/files#diff-2165823a8d82c5dd1353601bd290df8bd431f9ee2096750d9ef655cf5d251998R13 might be better. What do you think?