### PR TITLE
rust: update naersk url to nix-community/naersk

### DIFF
--- a/rust/flake.nix
+++ b/rust/flake.nix
@@ -1,7 +1,6 @@
 {
-
   inputs = {
-    naersk.url = "github:nmattia/naersk/master";
+    naersk.url = "github:nix-community/naersk/master";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     utils.url = "github:numtide/flake-utils";
   };
@@ -10,20 +9,18 @@
     utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
-        naersk-lib = pkgs.callPackage naersk {};
-      in {
-
+        naersk-lib = pkgs.callPackage naersk { };
+      in
+      {
         defaultPackage = naersk-lib.buildPackage ./.;
 
         defaultApp = utils.lib.mkApp {
-            drv = self.defaultPackage."${system}";
+          drv = self.defaultPackage."${system}";
         };
 
         devShell = with pkgs; mkShell {
           buildInputs = [ cargo rustc rustfmt pre-commit rustPackages.clippy ];
           RUST_SRC_PATH = rustPlatform.rustLibSrc;
         };
-
       });
-
 }


### PR DESCRIPTION
Update the URL of `naersk` in the rust template from https://github.com/nmattia/naersk to https://github.com/nix-community/naersk.

I tested by running:
  - `cargo init`
  - `nix flake init --template github:scvalex/templates/rust-update-naersk-url#rust`
  - `nix build`

The formatting changes are the result of applying `nixpkgs-fmt` to the file.