### PR TITLE
Haskell: Add support for x86_64-darwin

### DIFF
--- a/haskell-hello/flake.nix
+++ b/haskell-hello/flake.nix
@@ -4,7 +4,7 @@
   inputs.nixpkgs.url = "nixpkgs";
   outputs = { self, nixpkgs }:
     let
-      supportedSystems = [ "x86_64-linux" ];
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" ];
       forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
       nixpkgsFor = forAllSystems (system: import nixpkgs {
         inherit system;


### PR DESCRIPTION
This small PR just adds support for x86_64-darwin machines to the Haskell template. This was tested locally on a darwin machine by creating a project with this flake configuration. 