### PR TITLE
Update trivial template with nix 2.7 default package syntax

### DIFF
--- a/trivial/flake.nix
+++ b/trivial/flake.nix
@@ -5,7 +5,7 @@
 
     packages.x86_64-linux.hello = nixpkgs.legacyPackages.x86_64-linux.hello;
 
-    defaultPackage.x86_64-linux = self.packages.x86_64-linux.hello;
+    packages.x86_64-linux.default = self.packages.x86_64-linux.hello;
 
   };
 }


### PR DESCRIPTION
```
warning: flake output attribute 'defaultPackage' is deprecated; use 'packages.<system>.default' instead
```