### PR TITLE
Add package template

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,17 @@
         '';
       };
 
+      package = {
+        path = ./package;
+        description = "An standard package template";
+        welcomeText = ''
+          You just created a directory for a Nix package.
+          You can refer to this package in other Nix files using:
+
+            pkgs.callPackage ./package-directory { }
+        '';
+      };
+
     };
 
     defaultTemplate = self.templates.trivial;

--- a/package/default.nix
+++ b/package/default.nix
@@ -1,0 +1,58 @@
+{ lib
+, stdenv
+  # , fetchurl
+  # , fetchFromGitHub
+  # , fetchFromGitLab
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "mypackage";
+  version = "1.0.0";
+
+  # src = fetchurl {
+  #   url = "https://";
+  #   sha256 = lib.fakeHash;
+  # };
+
+  # src = fetchFromGitHub {
+  #   owner = "owner";
+  #   repo = pname;
+  #   rev = "v${version}";
+  #   sha256 = lib.fakeHash;
+  # };
+
+  # src = fetchFromGitLab {
+  #   domain = "";
+  #   owner = "";
+  #   repo = pname;
+  #   rev = "v${version}";
+  #   hash = lib.fakeHash;
+  # };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+  ];
+
+  meta = with lib; {
+    homepage = "https://";
+    description = "";
+    maintainers = with maintainers; [  ];
+
+    # license = licenses.mit;
+    # license = licenses.gpl3;
+    # license = licenses.free;
+    # license = licenses.gpl2;
+    # license = licenses.gpl2Plus;
+    # license = licenses.gpl3Plus;
+    # license = licenses.asl20;
+    # license = licenses.bsd3;
+
+    # platforms = platforms.linux;
+    # platforms = platforms.unix;
+    # platforms = platforms.all;
+  };
+}

--- a/package/default.nix
+++ b/package/default.nix
@@ -1,8 +1,8 @@
 { lib
 , stdenv
-  # , fetchurl
-  # , fetchFromGitHub
-  # , fetchFromGitLab
+# , fetchurl
+# , fetchFromGitHub
+# , fetchFromGitLab
 , pkg-config
 }:
 

--- a/package/default.nix
+++ b/package/default.nix
@@ -12,14 +12,14 @@ stdenv.mkDerivation rec {
 
   # src = fetchurl {
   #   url = "https://";
-  #   sha256 = lib.fakeHash;
+  #   hash = lib.fakeHash;
   # };
 
   # src = fetchFromGitHub {
   #   owner = "owner";
   #   repo = pname;
   #   rev = "v${version}";
-  #   sha256 = lib.fakeHash;
+  #   hash = lib.fakeHash;
   # };
 
   # src = fetchFromGitLab {


### PR DESCRIPTION
Currently there is no template to quickly create packages. Usually what I do is copy another default.nix file from nixpkgs, but removing all cruft from such a file sometimes results in leftovers.

Having some commented examples in the file to remove also helps to not look up in documentation / `licenses.nix`.

I was thinking this might be useful eventually to incorporate in the nixpkgs manual on how to create a package.

Might be useful to mention in Nixpkgs something like:

```sh
nix flake new --template templates#package pkgs/applications/graphics/my-application
```