### PR TITLE
add nixpkgs as input of "trivial" template

### DIFF
--- a/trivial/flake.nix
+++ b/trivial/flake.nix
@@ -1,6 +1,10 @@
 {
   description = "A very basic flake";
 
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+  };
+
   outputs = { self, nixpkgs }: {
 
     packages.x86_64-linux.hello = nixpkgs.legacyPackages.x86_64-linux.hello;


### PR DESCRIPTION
I had to give a nix training yesterday trying to explain nix, how flakes
are purer than nix <2.4 than I asked the students to run `nix flake init`
which doesnt generate any input.
It forces to introduce the concept of registry and makes it less "pure"
as now your inputs are hidden.
I add the inputs here to make it more newcomer friendly, and I think it
makes developinbg your own flake easier with inputs laid out fromn the
start.
see https://github.com/NixOS/nix/issues/7005
