### PR TITLE
Add example for devShells in go-hello

### DIFF
--- a/go-hello/flake.nix
+++ b/go-hello/flake.nix
@@ -51,6 +51,17 @@
             vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
           };
         });
+      
+      # Add dependencies that are only needed for development
+      devShells = forAllSystems (system:
+        let 
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [ go gopls gotools go-tools ];
+          };
+        });
 
       # The default package for 'nix build'. This makes sense if the
       # flake provides only one package or there is a clear "main"


### PR DESCRIPTION
It took me bit to figure out how to get development dependencies into a go project when converting from shell.nix to flake.nix. I'm hoping adding this here will help those following behind.

Some credit for working out how to do this from
https://xeiaso.net/blog/nix-flakes-1-2022-02-21