### PR TITLE
full: Mark nixosModule as deprecated

### DIFF
--- a/full/flake.nix
+++ b/full/flake.nix
@@ -132,7 +132,7 @@
     # # Same idea as overlay but a list or attrset of them.
     overlays = { exampleOverlay = self.overlay; };
 
-    # Default module, for use in dependent flakes
+    # Default module, for use in dependent flakes. Deprecated, use nixosModules.default instead.
     nixosModule = { config, ... }: { options = {}; config = {}; };
 
     # Same idea as nixosModule but a list or attrset of them.


### PR DESCRIPTION
`nixosModule` is deprecated in favor of `nixosModules.default`. See https://github.com/NixOS/nix/pull/6375.