### PR TITLE
Add LaTeX writing template with `latexmk`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,11 @@
         description = "A report built with Pandoc, XeLaTex and a custom font";
       };
 
+      latexmk = {
+        path = ./latexmk;
+        description = "A simple LaTeX template for writing documents with latexmk";
+      };
+
       go-hello = {
         path = ./go-hello;
         description = "A simple Go package";

--- a/latexmk/README.md
+++ b/latexmk/README.md
@@ -1,0 +1,34 @@
+# LaTeX template
+
+A LaTeX template for scientific writing, with a focus on reproducibility and ease of use.
+
+## Usage instructions
+
+### Build PDF
+
+Author changes in `main.tex` and `references.bib` as needed, and then compile to PDF with:
+
+```sh
+nix build
+```
+
+and look in the `result` directory for the PDF.
+
+### Interactive watch mode
+
+Have `latexmk` continuously watch for changes and recompile the PDF:
+
+```sh
+nix develop
+latexmk -interaction=nonstopmode -auxdir=.cache/latex -pdf -pvc main.tex
+```
+
+### Reduce size of build environment
+
+If you know you won't need all the LaTeX packages included with TeX Live, you can make the build environment smaller by replacing `texliveFull` in `buildInputs` with `texlive.combine` and including only what you need. For example:
+
+```nix
+(texlive.combine { inherit (texlive) latexmk scheme-basic biblatex biber; })
+```
+
+However, by doing this you'll need to find the corresponding Nix package in the `nixpkgs` repository, and add it to the environment manually whenever you want to include a new LaTeX package. For this reason, it can be easier during writing to just use `texliveFull` unless you have a specific need not to.

--- a/latexmk/default.nix
+++ b/latexmk/default.nix
@@ -1,0 +1,17 @@
+{ pkgs ? import <nixpkgs> { }, ... }:
+
+pkgs.stdenv.mkDerivation {
+  name = "pdf";
+  src = ./.;
+  buildInputs = with pkgs; [
+    texliveFull
+  ];
+  buildPhase = ''
+    mkdir -p .cache/latex
+    latexmk -interaction=nonstopmode -auxdir=.cache/latex -pdf main.tex
+  '';
+  installPhase = ''
+    mkdir -p $out
+    cp main.pdf $out
+  '';
+}

--- a/latexmk/flake.nix
+++ b/latexmk/flake.nix
@@ -1,0 +1,16 @@
+{
+  description = "A simple LaTeX template for writing documents with latexmk";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages.default = pkgs.callPackage ./default.nix { };
+      });
+}

--- a/latexmk/main.tex
+++ b/latexmk/main.tex
@@ -1,0 +1,17 @@
+\documentclass{article}
+
+\usepackage[backend=biber]{biblatex}
+\addbibresource{references.bib}
+
+\begin{document}
+
+\title{My Article}
+\author{Me}
+\date{1970-01-01}
+\maketitle
+
+\cite{key}
+
+\printbibliography
+
+\end{document}

--- a/latexmk/references.bib
+++ b/latexmk/references.bib
@@ -1,0 +1,5 @@
+@misc{key,
+    author = "Author",
+    title = "Title",
+    year = "1970"
+}


### PR DESCRIPTION
Having a local development environment for LaTeX is a real nightmare. Nix and nixpkgs bring some sanity to that world but I was surprised to see that there wasn't a straightforward LaTeX flake template for just getting a simple `main.tex` compiled to PDF.

I've added a simple template here for getting people from scientific writing interested in the Nix ecosystem.

Please provide feedback and I'll tweak this accordingly!