### PR TITLE
Use vendorHash instead of deprecated sha256

### DIFF
--- a/go-hello/flake.nix
+++ b/go-hello/flake.nix
@@ -41,20 +41,20 @@
             # This hash locks the dependencies of this package. It is
             # necessary because of how Go requires network access to resolve
             # VCS.  See https://www.tweag.io/blog/2021-03-04-gomod2nix/ for
-            # details. Normally one can build with a fake sha256 and rely on native Go
+            # details. Normally one can build with a fake hash and rely on native Go
             # mechanisms to tell you what the hash should be or determine what
             # it should be "out-of-band" with other tooling (eg. gomod2nix).
             # To begin with it is recommended to set this, but one must
             # remember to bump this hash when your dependencies change.
-            #vendorSha256 = pkgs.lib.fakeSha256;
+            # vendorHash = pkgs.lib.fakeHash;
 
-            vendorSha256 = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+            vendorHash = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
           };
         });
-      
+
       # Add dependencies that are only needed for development
       devShells = forAllSystems (system:
-        let 
+        let
           pkgs = nixpkgsFor.${system};
         in
         {


### PR DESCRIPTION
Nix warns about using a deprectated hash format. This updates the template to the new format.