### PR TITLE
chore: update install-nix-action to latest; fix nix build command

### DIFF
--- a/rust/.github/workflows/build_nix.yml
+++ b/rust/.github/workflows/build_nix.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v12
+      - uses: cachix/install-nix-action@v26
       - name: Building package
-        run: nix-build . -A defaultPackage.x86_64-linux
+        run: nix build 


### PR DESCRIPTION
This updates the nix flake template for Rust projects - it was ~11 major versions behind on the github action which now uses Nix flake etc