### PR TITLE
(rust-web-server) add readme + move server to use 0.0.0.0 instead of 127.0.0.1

### DIFF
--- a/rust-web-server/README.md
+++ b/rust-web-server/README.md
@@ -1,0 +1,13 @@
+## How to use this
+
+To build
+
+```
+nix build
+```
+
+To build and run
+
+```
+nix run
+```

--- a/rust-web-server/src/main.rs
+++ b/rust-web-server/src/main.rs
@@ -7,7 +7,7 @@ fn config(cfg: &mut web::ServiceConfig) {
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     HttpServer::new(|| App::new().configure(config))
-        .bind("127.0.0.1:8080")?
+        .bind("0.0.0.0:8080")?
         .run()
         .await
 }


### PR DESCRIPTION
currently the server doesn't have a readme so I added a quick one to just get people started. Now, the main issue I found with this example is that it uses `127.0.0.1` which only works for localhost. I think most people want this example to work on a remote host as well, so I am moving the default bind address to `0.0.0.0` so everyone can build and run on a remote server by default.