### PR TITLE
minor refactor in flake.nix

### DIFF
--- a/rust/flake.nix
+++ b/rust/flake.nix
@@ -17,5 +17,6 @@
           buildInputs = [ cargo rustc rustfmt pre-commit rustPackages.clippy ];
           RUST_SRC_PATH = rustPlatform.rustLibSrc;
         };
-      });
+      }
+    );
 }


### PR DESCRIPTION
appended a newline before ');', slightly improving the visibility of the  block scope. This is in compliance with the rnix lsp's formatter :D