### PR TITLE
Use numtide/flake-utils in haskell.nix template

### DIFF
--- a/haskell.nix/flake.nix
+++ b/haskell.nix/flake.nix
@@ -2,7 +2,7 @@
   # This is a template created by `hix init`
   inputs.haskellNix.url = "github:input-output-hk/haskell.nix";
   inputs.nixpkgs.follows = "haskellNix/nixpkgs-unstable";
-  inputs.flake-utils.follows = "haskellNix/flake-utils";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
   outputs = { self, nixpkgs, flake-utils, haskellNix }:
     let
       supportedSystems = [


### PR DESCRIPTION
#67 had some bit rot when it was merged.  Haskell.nix does not depend on `flake-utils` internally any more (so we can't get the patched version from there).

Now that https://github.com/numtide/flake-utils/pull/97 is merged we can use `numtide/flake-utils` directly in this template.