### PR TITLE
fix: Updated the Go template to use Go 1.23 instead of 1.16!

### DIFF
--- a/go-hello/flake.nix
+++ b/go-hello/flake.nix
@@ -48,7 +48,7 @@
             # remember to bump this hash when your dependencies change.
             # vendorHash = pkgs.lib.fakeHash;
 
-            vendorHash = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
+            vendorHash = null;
           };
         });
 

--- a/go-hello/flake.nix
+++ b/go-hello/flake.nix
@@ -2,7 +2,7 @@
   description = "A simple Go package";
 
   # Nixpkgs / NixOS version to use.
-  inputs.nixpkgs.url = "nixpkgs/nixos-21.11";
+  inputs.nixpkgs.url = "nixpkgs/nixos-24.11";
 
   outputs = { self, nixpkgs }:
     let

--- a/go-hello/flake.nix
+++ b/go-hello/flake.nix
@@ -2,7 +2,7 @@
   description = "A simple Go package";
 
   # Nixpkgs / NixOS version to use.
-  inputs.nixpkgs.url = "nixpkgs/nixos-24.11";
+  inputs.nixpkgs.url = "nixpkgs/nixos-26.05";
 
   outputs = { self, nixpkgs }:
     let

--- a/go-hello/go.mod
+++ b/go-hello/go.mod
@@ -1,3 +1,3 @@
 module example.com/go-hello
 
-go 1.16
+go 1.23


### PR DESCRIPTION
Hello! I've been programming some projects in Go recently and I really like the templates! But I can see that the go version used for the template is a little old, this PR aims to update the go version of the package and the dev environment to 1.23 to make it easier to start a go project on the most recent stable version.