### PR TITLE
Modernize go-hello template

### DIFF
--- a/go-hello/flake.nix
+++ b/go-hello/flake.nix
@@ -2,9 +2,10 @@
   description = "A simple Go package";
 
   # Nixpkgs / NixOS version to use.
-  inputs.nixpkgs.url = "nixpkgs/nixos-21.11";
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
 
       # to work with older version of flakes
@@ -14,7 +15,12 @@
       version = builtins.substring 0 8 lastModifiedDate;
 
       # System types to support.
-      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+      supportedSystems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
 
       # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
@@ -24,14 +30,18 @@
 
     in
     {
-
       # Provide some binary packages for selected system types.
-      packages = forAllSystems (system:
+      packages = forAllSystems (
+        system:
         let
           pkgs = nixpkgsFor.${system};
         in
         {
-          go-hello = pkgs.buildGoModule {
+
+          # The default package for 'nix build'. This makes sense if the
+          # flake provides only one package or there is a clear "main"
+          # package.
+          default = pkgs.buildGoModule {
             pname = "go-hello";
             inherit version;
             # In 'nix develop', we don't need a copy of the source tree
@@ -50,22 +60,25 @@
 
             vendorHash = "sha256-pQpattmS9VmO3ZIQUFn66az8GSmB4IvYhTTCFn6SUmo=";
           };
-        });
+        }
+      );
 
       # Add dependencies that are only needed for development
-      devShells = forAllSystems (system:
+      devShells = forAllSystems (
+        system:
         let
           pkgs = nixpkgsFor.${system};
         in
         {
           default = pkgs.mkShell {
-            buildInputs = with pkgs; [ go gopls gotools go-tools ];
+            buildInputs = with pkgs; [
+              go
+              gopls
+              gotools
+              go-tools
+            ];
           };
-        });
-
-      # The default package for 'nix build'. This makes sense if the
-      # flake provides only one package or there is a clear "main"
-      # package.
-      defaultPackage = forAllSystems (system: self.packages.${system}.go-hello);
+        }
+      );
     };
 }

--- a/go-hello/go.mod
+++ b/go-hello/go.mod
@@ -1,3 +1,3 @@
 module example.com/go-hello
 
-go 1.16
+go 1.24


### PR DESCRIPTION
Rebased onto current master, keeping only the part that's still relevant: dropping go-hello's deprecated `defaultPackage` output in favor of `packages.default`.

The Go version bump, nixpkgs pin, and reformatting from the original PR are already covered on master by #89, #100, and #105.