### PR TITLE
Move channels to tarballs

### DIFF
--- a/bash-hello/flake.nix
+++ b/bash-hello/flake.nix
@@ -2,7 +2,7 @@
   description = "An over-engineered Hello World in bash";
 
   # Nixpkgs / NixOS version to use.
-  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-21.05/nixexprs.tar.xz";
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-21.05/nixexprs.tar.zst";
 
   outputs = { self, nixpkgs }:
     let

--- a/bash-hello/flake.nix
+++ b/bash-hello/flake.nix
@@ -2,7 +2,7 @@
   description = "An over-engineered Hello World in bash";
 
   # Nixpkgs / NixOS version to use.
-  inputs.nixpkgs.url = "nixpkgs/nixos-21.05";
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-21.05/nixexprs.tar.xz";
 
   outputs = { self, nixpkgs }:
     let

--- a/c-hello/flake.nix
+++ b/c-hello/flake.nix
@@ -2,7 +2,7 @@
   description = "An over-engineered Hello World in C";
 
   # Nixpkgs / NixOS version to use.
-  inputs.nixpkgs.url = "nixpkgs/nixos-21.05";
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-21.05/nixexprs.tar.xz";
 
   outputs = { self, nixpkgs }:
     let

--- a/c-hello/flake.nix
+++ b/c-hello/flake.nix
@@ -2,7 +2,7 @@
   description = "An over-engineered Hello World in C";
 
   # Nixpkgs / NixOS version to use.
-  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-21.05/nixexprs.tar.xz";
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-21.05/nixexprs.tar.zst";
 
   outputs = { self, nixpkgs }:
     let

--- a/dotnet/flake.nix
+++ b/dotnet/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Hello World in .NET";
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs = {

--- a/dotnet/flake.nix
+++ b/dotnet/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Hello World in .NET";
   inputs = {
-    nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
+    nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.zst";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs = {

--- a/full/flake.nix
+++ b/full/flake.nix
@@ -13,6 +13,9 @@
   # A flake in some absolute path
   # inputs.otherDir.url = "path:/home/alice/src/patchelf";
 
+  # Recommended: nixpkgs zstd tarball using the lockable tarball protocol
+  inputs.nixpkgsLockableTarball.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.zst";
+
   # The nixpkgs entry in the flake registry.
   inputs.nixpkgsRegistry.url = "nixpkgs";
 

--- a/go-hello/flake.nix
+++ b/go-hello/flake.nix
@@ -2,7 +2,7 @@
   description = "A simple Go package";
 
   # Nixpkgs / NixOS version to use.
-  inputs.nixpkgs.url = "nixpkgs/nixos-21.11";
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-21.11/nixexprs.tar.xz";
 
   outputs = { self, nixpkgs }:
     let

--- a/go-hello/flake.nix
+++ b/go-hello/flake.nix
@@ -2,7 +2,7 @@
   description = "A simple Go package";
 
   # Nixpkgs / NixOS version to use.
-  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-21.11/nixexprs.tar.xz";
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-21.11/nixexprs.tar.zst";
 
   outputs = { self, nixpkgs }:
     let

--- a/haskell-flake/flake.nix
+++ b/haskell-flake/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
+    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.zst";
     flake-parts.url = "github:hercules-ci/flake-parts";
     haskell-flake.url = "github:srid/haskell-flake";
   };

--- a/haskell-flake/flake.nix
+++ b/haskell-flake/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
     flake-parts.url = "github:hercules-ci/flake-parts";
     haskell-flake.url = "github:srid/haskell-flake";
   };

--- a/haskell-hello/flake.nix
+++ b/haskell-hello/flake.nix
@@ -1,7 +1,7 @@
 {
   # inspired by: https://serokell.io/blog/practical-nix-flakes#packaging-existing-applications
   description = "A Hello World in Haskell with a dependency and a devShell";
-  inputs.nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.zst";
   outputs = { self, nixpkgs }:
     let
       supportedSystems = [ "x86_64-linux" "x86_64-darwin" ];

--- a/haskell-hello/flake.nix
+++ b/haskell-hello/flake.nix
@@ -1,7 +1,7 @@
 {
   # inspired by: https://serokell.io/blog/practical-nix-flakes#packaging-existing-applications
   description = "A Hello World in Haskell with a dependency and a devShell";
-  inputs.nixpkgs.url = "nixpkgs";
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
   outputs = { self, nixpkgs }:
     let
       supportedSystems = [ "x86_64-linux" "x86_64-darwin" ];

--- a/latexmk/flake.nix
+++ b/latexmk/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "A simple LaTeX template for writing documents with latexmk";
   inputs = {
-    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
+    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.zst";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/latexmk/flake.nix
+++ b/latexmk/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "A simple LaTeX template for writing documents with latexmk";
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/python/flake.nix
+++ b/python/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.zst";
   inputs.poetry2nix.url = "github:nix-community/poetry2nix";
 
   outputs = { self, nixpkgs, poetry2nix }:

--- a/python/flake.nix
+++ b/python/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
   inputs.poetry2nix.url = "github:nix-community/poetry2nix";
 
   outputs = { self, nixpkgs, poetry2nix }:

--- a/ruby/flake.nix
+++ b/ruby/flake.nix
@@ -3,7 +3,7 @@
   # Useage: see README.md
   
   inputs = {
-    nixpkgs.url = "https://channels.nixos.org/nixos-24.05/nixexprs.tar.xz";
+    nixpkgs.url = "https://channels.nixos.org/nixos-24.05/nixexprs.tar.zst";
     flake-utils.url = "github:numtide/flake-utils";
 };
 

--- a/ruby/flake.nix
+++ b/ruby/flake.nix
@@ -3,7 +3,7 @@
   # Useage: see README.md
   
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "https://channels.nixos.org/nixos-24.05/nixexprs.tar.xz";
     flake-utils.url = "github:numtide/flake-utils";
 };
 

--- a/rust-web-server/flake.nix
+++ b/rust-web-server/flake.nix
@@ -4,7 +4,7 @@
   # Nixpkgs / NixOS version to use.
   inputs.nixpkgs.url = "https://channels.nixos.org/nixos-21.05/nixexprs.tar.xz";
 
-  inputs.import-cargo.url = github:edolstra/import-cargo;
+  inputs.import-cargo.url = "github:edolstra/import-cargo";
 
   outputs = { self, nixpkgs, import-cargo }:
     let

--- a/rust-web-server/flake.nix
+++ b/rust-web-server/flake.nix
@@ -2,7 +2,7 @@
   description = "A Rust web server including a NixOS module";
 
   # Nixpkgs / NixOS version to use.
-  inputs.nixpkgs.url = "nixpkgs/nixos-21.05";
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-21.05/nixexprs.tar.xz";
 
   inputs.import-cargo.url = github:edolstra/import-cargo;
 

--- a/rust-web-server/flake.nix
+++ b/rust-web-server/flake.nix
@@ -2,7 +2,7 @@
   description = "A Rust web server including a NixOS module";
 
   # Nixpkgs / NixOS version to use.
-  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-21.05/nixexprs.tar.xz";
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-21.05/nixexprs.tar.zst";
 
   inputs.import-cargo.url = "github:edolstra/import-cargo";
 

--- a/rust/flake.nix
+++ b/rust/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     naersk.url = "github:nix-community/naersk/master";
-    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
+    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.zst";
     utils.url = "github:numtide/flake-utils";
   };
 

--- a/rust/flake.nix
+++ b/rust/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     naersk.url = "github:nix-community/naersk/master";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
     utils.url = "github:numtide/flake-utils";
   };
 

--- a/simple-container/flake.nix
+++ b/simple-container/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-20.03/nixexprs.tar.xz";
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-20.03/nixexprs.tar.zst";
 
   outputs = { self, nixpkgs }: {
 

--- a/simple-container/flake.nix
+++ b/simple-container/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-20.03";
+  inputs.nixpkgs.url = "https://channels.nixos.org/nixos-20.03/nixexprs.tar.xz";
 
   outputs = { self, nixpkgs }: {
 

--- a/trivial/flake.nix
+++ b/trivial/flake.nix
@@ -2,7 +2,7 @@
   description = "A very basic flake";
 
   inputs = {
-    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
+    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.zst";
   };
 
   outputs = { self, nixpkgs }: {

--- a/trivial/flake.nix
+++ b/trivial/flake.nix
@@ -2,7 +2,7 @@
   description = "A very basic flake";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
   };
 
   outputs = { self, nixpkgs }: {

--- a/typescript/pnpm-p5js/flake.nix
+++ b/typescript/pnpm-p5js/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
   };
 
   outputs = inputs:

--- a/typescript/pnpm-p5js/flake.nix
+++ b/typescript/pnpm-p5js/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
+    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.zst";
   };
 
   outputs = inputs:

--- a/typescript/pnpm/flake.nix
+++ b/typescript/pnpm/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
   };
 
   outputs = inputs:

--- a/typescript/pnpm/flake.nix
+++ b/typescript/pnpm/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
+    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.zst";
   };
 
   outputs = inputs:


### PR DESCRIPTION
See [this thread](https://discourse.nixos.org/t/danish-road-traffic-authority-switches-from-microsoft-to-linux/74117/24) for full context.

TL:DR; the channel tarballs are actually _ahead_ of the GitHub and with the [lockable tarball protocol](https://nix.dev/manual/nix/2.33/protocols/tarball-fetcher#lockable-http-tarball-protocol) being a thing, they should probably be used.

This PR also removes a URL literal in `rust-web-server` which have been deprecated.

I'm not certain what to do with `full` though.

# TO-DO
- [x] Move over easy examples that use `github:` to `channels.nixos.org`.
- [x] Move over examples that use `nixpkgs` from the registry (as these [also link to GitHub](https://github.com/NixOS/flake-registry/blob/cb70c9306b44501de412649c356dee503a25f119/flake-registry.json#L334-L345)).
- [x] Figure out what to do with `full`, should it be moved over to the channel tarballs or have an example of it at least?